### PR TITLE
Release 2.0.0-beta.37

### DIFF
--- a/lib/scripts/properties/process-configured-color.js
+++ b/lib/scripts/properties/process-configured-color.js
@@ -99,19 +99,14 @@ function process_configured_color(
                 ].default;
             }
           }
-          let opacity = 1;
+          let opacity = '1';
           if (parsed_color.groups.opacity) {
-            opacity = parseFloat(parsed_color.groups.opacity.substring(1));
-            if (opacity.toString().length === 1) {
-              opacity = opacity * 10;
-            }
+            opacity = parsed_color.groups.opacity;
             // Convert the number to a working opacity value
-            if (opacity >= 100) {
-              opacity = 1;
-            } else if (opacity === 0) {
-              opacity = 0;
-            } else {
-              opacity = opacity / 100;
+            if (parsed_color.groups.opacity === '.100') {
+              opacity = '1';
+            } else if (parsed_color.groups.opacity === '.0') {
+              opacity = '0';
             }
           }
           processed = 'rgba(' + processed + ', ' + opacity + ')';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydrogen-css/hydrogen",
-  "version": "2.0.0-beta.36",
+  "version": "2.0.0-beta.37",
   "description": "An open-source, inline CSS framework powered by data-attributes. MIT Licensed.",
   "keywords": [
     "Hydrogen",

--- a/releases/2.0.0-beta.37.js
+++ b/releases/2.0.0-beta.37.js
@@ -1,0 +1,25 @@
+// Hydrogen data models
+let Release = require('../lib/data/release-model-definition');
+/**
+ * @typedef {import('../lib/data/release-model-definition').Release} Release
+ * @typedef {import('../lib/data/release-model-definition').Change} Change
+ * @typedef {import('../lib/data/release-model-definition').Language} Language
+ */
+
+// Release
+/** @type {Release} */
+module.exports = {
+  version: '2.0.0-beta.37',
+  date: new Date('2023-01-10'),
+  author: 'Josh Beveridge',
+  bugfixes: [
+    {
+      breaking: false,
+      changes: {
+        en: [
+          'Fixes a bug that was causing color opacity modifiers to break because of the way the value was being parsed as a number.',
+        ],
+      },
+    },
+  ],
+};

--- a/tests/test-basics/input/index.html
+++ b/tests/test-basics/input/index.html
@@ -37,6 +37,12 @@
     <div data-h2-accent-color="base(primary)"></div>
     <div data-h2-background="base(primary)"></div>
     <div data-h2-background-color="base(primary)"></div>
+    <div data-h2-background-color="base(primary.1)"></div>
+    <div data-h2-background-color="base(primary.01)"></div>
+    <div data-h2-background-color="base(primary.10)"></div>
+    <div data-h2-background-color="base(primary.100)"></div>
+    <div data-h2-background-color="base(primary.010)"></div>
+    <div data-h2-background-color="base(primary.0)"></div>
     <div data-h2-border="base(1px solid primary)"></div>
     <div data-h2-border="base(x20 solid primary)"></div>
     <div data-h2-box-shadow="base(small)"></div>


### PR DESCRIPTION
# 📝 Purpose

Addresses an issue with opacity modifiers.

# 🧪 Changes

## Bugfixes

- Fixes a bug where color opacity modifiers were being incorrectly parsed as numbers, causing bad opacity values in the final styles.