### PR TITLE
Release 2.0.0-beta.40

### DIFF
--- a/lib/scripts/properties/process-configured-color.js
+++ b/lib/scripts/properties/process-configured-color.js
@@ -18,7 +18,6 @@
  */
 
 // Data imports
-const { get_modifier_data } = require('../../data/modifiers-model');
 
 // Logging
 
@@ -82,6 +81,14 @@ function process_configured_color(
           if (query.modifiers.mode === 'all') {
             processed =
               settings.variables.colors[parsed_color.groups.color].all;
+          } else if (
+            query.modifiers.mode === 'dark' &&
+            settings.modes &&
+            settings.modes['dark'] &&
+            settings.modes['dark'].automatic
+          ) {
+            processed =
+              settings.variables.colors[parsed_color.groups.color].all;
           } else {
             processed =
               settings.variables.colors[parsed_color.groups.color].default;
@@ -99,16 +106,10 @@ function process_configured_color(
               settings.modes['dark'] &&
               settings.modes['dark'].automatic_modifiers
             ) {
-              let modifier_data = get_modifier_data();
-              modifier_data.forEach((item) => {
-                if (item.key === modifier) {
-                  modifier = item.opposite;
-                }
-              });
               processed =
                 settings.variables.colors[parsed_color.groups.color].modifiers[
                   modifier
-                ].default;
+                ].all;
             } else {
               processed =
                 settings.variables.colors[parsed_color.groups.color].modifiers[

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydrogen-css/hydrogen",
-  "version": "2.0.0-beta.39",
+  "version": "2.0.0-beta.40",
   "description": "An open-source, inline CSS framework powered by data-attributes. MIT Licensed.",
   "keywords": [
     "Hydrogen",

--- a/releases/2.0.0-beta.40.js
+++ b/releases/2.0.0-beta.40.js
@@ -1,0 +1,26 @@
+// Hydrogen data models
+let Release = require('../lib/data/release-model-definition');
+/**
+ * @typedef {import('../lib/data/release-model-definition').Release} Release
+ * @typedef {import('../lib/data/release-model-definition').Change} Change
+ * @typedef {import('../lib/data/release-model-definition').Language} Language
+ */
+
+// Release
+/** @type {Release} */
+module.exports = {
+  version: '2.0.0-beta.40',
+  date: new Date('2023-01-26'),
+  author: 'Josh Beveridge',
+  features: [
+    {
+      breaking: true,
+      changes: {
+        en: [
+          'Enhances the functionality from the previous release by enabling the fixed use of any configured color in dark mode when the automatic setting is enabled.',
+          'This means that if you set black to automatically swap to white but need black explicitly in dark mode, you can simply define <code>:dark(black)</code>.',
+        ],
+      },
+    },
+  ],
+};


### PR DESCRIPTION
# 📝 Purpose

Enhances color usage in automatic dark mode.

# 🧪 Changes

## Features

- Breaking: enhances the functionality released in `beta.39` by allowing any color to be explicitly used in dark mode rather than having to manually specify an opposite.